### PR TITLE
Description as parameter instead of in options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ response '201', 'blog created' do
 end
 ```
 
-If you want to customize the description of the generated specification, the `description` option can be passed to **run_test!**
+If you want to customize the description of the generated specification, a description can be passed to **run_test!**
 
 ```ruby
 response '201', 'blog created' do
-  run_test! description: "custom spec description"
+  run_test! "custom spec description"
 end
 ```
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,13 +117,19 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
-      # @param description [String] description of the test
+      # @param args [Array] arguments to pass to the `it` method
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(description = nil, **options, &block)
+      def run_test!(*args, **options, &block)
+        # rswag metadata value defaults to true
         options[:rswag] = true unless options.key?(:rswag)
+
+        # The first argument passed to `it` is the description. If it's not provided,
+        # we'll generate a default description based on the HTTP code of the response
+        description, *rest = *args
         description ||= "returns a #{metadata[:response][:code]} response"
+        args = [description, *rest]
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -131,7 +137,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it description, **options do
+          it *args, **options do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -140,7 +146,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it description, **options do |example|
+          it *args, **options do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,12 +117,13 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
+      # @param description [String] description of the test
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(**options, &block)
+      def run_test!(description = nil, **options, &block)
         options[:rswag] = true unless options.key?(:rswag)
-        description = options.delete(:description) || "returns a #{metadata[:response][:code]} response"
+        description ||= "returns a #{metadata[:response][:code]} response"
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,19 +117,16 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
+      # @param description [String] description of the test
       # @param args [Array] arguments to pass to the `it` method
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(*args, **options, &block)
+      def run_test!(description = nil, *args, **options, &block)
         # rswag metadata value defaults to true
         options[:rswag] = true unless options.key?(:rswag)
 
-        # The first argument passed to `it` is the description. If it's not provided,
-        # we'll generate a default description based on the HTTP code of the response
-        description, *rest = *args
         description ||= "returns a #{metadata[:response][:code]} response"
-        args = [description, *rest]
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -137,7 +134,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it *args, **options do
+          it description, *args, **options do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -146,7 +143,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it *args, **options do |example|
+          it description, *args, **options do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -237,7 +237,6 @@ module Rswag
         before do
           stub_const("RSPEC_VERSION", rspec_version)
           allow(subject).to receive(:before)
-          allow(subject).to receive(:description)
         end
 
         it "executes a specification" do
@@ -250,7 +249,7 @@ module Rswag
           it "executes a specification described with passed description" do
             expected_spec_description = "returns a 200 response - with a custom description"
             expect(subject).to receive(:it).with(expected_spec_description, rswag: true)
-            subject.run_test!(description: expected_spec_description)
+            subject.run_test!(expected_spec_description)
           end
         end
       end


### PR DESCRIPTION
# 87dd8f6378898071526151dcc4100cd0d66ede74
## Problem
If for some reason `:description` was a key in the metadata hash that we wanted to pass into `it` through `run_test!`, the proposed changes would prevent us from doing that.

## Solution
Add a description parameter to `run_test!` instead of extracting it from the `options` hash.

# 6e3d5c8c048d19dee97aca4ed9c8560d28a23f1a
This commit adds support for passing in any parameters to `it` through `run_test!`.  This an additional enhancement - if you feel like it's too much for this PR, you can revert this commit and I can open up a seperate PR for this change afterwards.
It follows a similar pattern as the `it` method itself:

https://github.com/rspec/rspec-core/blob/5e0414295d4353ebffcc432399cbb96999495943/lib/rspec/core/example_group.rb#L161

https://github.com/rspec/rspec-core/blob/5e0414295d4353ebffcc432399cbb96999495943/lib/rspec/core/example_group.rb#L145-L155
